### PR TITLE
Added start Http and Webpack servers with one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,16 +121,16 @@ In order to set up the project locally, perform the following steps:
 |------------------------|------------|
 | `start-webpack`        | Starts the webpack development server, responsible for asset compilation and hot reload. |
 | `start-dev`            | Starts the application server in development mode. |
+| `dev`                  | Starts the task at the same time: `start-webpack` and` start-dev` |
 | `start`                | Run in production mode. |
 
 ### Running in development mode
 
 Two separate servers need to be started. The first one is the actual application in development mode. The second server is the webpack server which is to be run at all times for hot replace
 
-* Start application HTTP server: `npm run start-dev`.
-* Start application Webpack server: `npm run start-webpack`.
+* Start application HTTP and Webpack server: `npm run dev`.
 
-If you are running this on Mac, you would use two separate terminal windows and leave both servers running. To open the app:
+To open the app:
 
 * Navigate to `http://localhost:4444`, unless you specified a different port.
 

--- a/package.json
+++ b/package.json
@@ -46,9 +46,21 @@
     "build-mui-icon-list": "./node_modules/.bin/babel-node ./scripts/build-mui-icon-list.js",
     "config-da-memory": "./node_modules/.bin/replace da_cassandra da_memory ./data/da/*",
     "config-da-cassandra": "./node_modules/.bin/replace da_memory da_cassandra ./data/da/*",
-    "start-webpack": "./node_modules/.bin/webpack-dev-server --hot --inline --progress --colors",
-    "start-dev": "export NODE_ENV=development && nodemon --exec ./node_modules/.bin/babel-node -- ./server/server.js",
-    "start": "export NODE_ENV=production && ./node_modules/.bin/babel-node ./server/server.js"
+    "start-webpack": "better-npm-run start-webpack",
+    "start-dev": "better-npm-run start-dev",
+    "start": "export NODE_ENV=production && ./node_modules/.bin/babel-node ./server/server.js",
+    "dev": "concurrent --kill-others \"npm run start-webpack\" \"npm run start-dev\""
+  },
+  "betterScripts": {
+    "start-dev": {
+      "command": "nodemon --exec ./node_modules/.bin/babel-node -- ./server/server.js",
+      "env": {
+        "NODE_ENV": "development"
+      }
+    },
+    "start-webpack": {
+      "command": "./node_modules/.bin/webpack-dev-server --hot --inline --progress --colors"
+    }
   },
   "metadata": {
     "graphql": {
@@ -105,6 +117,8 @@
   "devDependencies": {
     "babel-plugin-transform-runtime": "^6.3.13",
     "recursive-readdir-sync": "^1.0.6",
-    "webpack-dev-server": "^1.14.0"
+    "webpack-dev-server": "^1.14.0",
+    "better-npm-run": "^0.0.5",
+    "concurrently": "^0.1.1"
   }
 }


### PR DESCRIPTION
I'm sick to keep open two terminals))
So I added the ability to run two servers (Nttp and Webpack) with a single command. 
I hope this opportunity will be useful to others.